### PR TITLE
A Liquid Tag to Build The Home Page

### DIFF
--- a/_plugins/layout_row_tab.rb
+++ b/_plugins/layout_row_tab.rb
@@ -56,9 +56,11 @@ class LayoutRow < Liquid::Tag
       
       output += "style=\"background-image:url(#{baseUrl}/img/#{data["img"]});\">\n"
       output += "<p class=\"news-title\">#{data["title"]}</p>\n"
-      #Fix this by stripping the html from the excerpt.
       excerptHtml = post.data["excerpt"]
-      excerpt = "#{excerptHtml}".gsub(/<\/?[^>]*>/, "")[0..80]
+      
+      template = Liquid::Template.parse(" {{ \"#{excerptHtml}\" | strip_html | truncate: 80 }}")
+      excerpt = template.render
+      
       output += "<p class=\"news-exp\">#{excerpt}</p>\n"
       output += "</div>\n"
       output += "</a>\n"

--- a/_plugins/layout_row_tab.rb
+++ b/_plugins/layout_row_tab.rb
@@ -1,0 +1,74 @@
+
+class LayoutRow < Liquid::Tag
+  def initialize(tag_name, input, tokens)
+    super
+    @input = input
+    @tokens = tokens
+  end
+  
+  def lookup(context, name)
+    lookup = context
+    name.split(".").each { |value| lookup = lookup[value] }
+    lookup
+  end
+  
+  def render(context)
+    columnMap = ["twelve", "six", "four", "three"]
+    
+    input_split = @input.split("|")
+    
+    start = input_split[0].strip.to_i
+    cols  = input_split[1].strip.to_i
+    
+    baseUrl = lookup(context, 'site.baseurl')
+    sitePosts = lookup(context, 'site.posts')
+    i = start
+    
+    if start > sitePosts.length
+      return ""
+    end
+    
+    iterEnd = 0
+    if sitePosts.length - 1 > start + cols
+      iterEnd = start + cols
+      else
+      iterEnd = sitePosts.length - 1
+    end
+    
+    output = ""
+
+    until i >= iterEnd
+      post = sitePosts[i]
+      data = post.data
+      output += "<a href=\"" + "#{baseUrl}" + "#{post.url}" + "\">\n"
+      
+      output += "<div class=\"" + columnMap[cols - 1] + " columns news-piece news-piece-2 "
+      if i == start && cols == 3 || cols == 4
+          output += "border-2"
+        elsif i != start + cols - 1
+          output += "border"
+        else
+        putc "testing"
+      end
+      
+      output += "\" "
+      
+      output += "style=\"background-image:url(#{baseUrl}/img/#{data["img"]});\">\n"
+      output += "<p class=\"news-title\">#{data["title"]}</p>\n"
+      #Fix this by stripping the html from the excerpt.
+      excerptHtml = post.data["excerpt"]
+      excerpt = "#{excerptHtml}".gsub(/<\/?[^>]*>/, "")[0..80]
+      output += "<p class=\"news-exp\">#{excerpt}</p>\n"
+      output += "</div>\n"
+      output += "</a>\n"
+      
+      i += 1
+    end
+    
+    return output
+  end
+  
+  
+end
+
+Liquid::Template.register_tag("layout_row", LayoutRow)

--- a/_plugins/layout_row_tab.rb
+++ b/_plugins/layout_row_tab.rb
@@ -30,9 +30,10 @@ class LayoutRow < Liquid::Tag
     
     iterEnd = 0
     if sitePosts.length - 1 > start + cols
-      iterEnd = start + cols
+        iterEnd = start + cols
       else
-      iterEnd = sitePosts.length - 1
+        iterEnd = sitePosts.length - 1
+        cols = iterEnd - start
     end
     
     output = ""

--- a/index.html
+++ b/index.html
@@ -6,116 +6,50 @@ quote-by: Krishna
 ---
 
 <div class="row first-row">
-<a href="{{site.baseurl}}{{site.posts[0].url}}">
-        <div class="eight columns news-piece news-piece-1 border" style="background-image: url({{site.baseurl}}/img/{{site.posts[0].img}})">
-        <p class="news-title">{{site.posts[0].title}}</p>
-        <p class="news-exp">{{site.posts[0].excerpt | strip_html | truncate: 80 }}</p>
-        </div>
-</a>
-    
-<a href="{{site.baseurl}}{{site.posts[1].url}}">
+  <a href="{{site.baseurl}}{{site.posts[0].url}}">
+    <div class="eight columns news-piece news-piece-1 border" style="background-image: url({{site.baseurl}}/img/{{site.posts[0].img}})">
+      <p class="news-title">{{site.posts[0].title}}</p>
+      <p class="news-exp">{{site.posts[0].excerpt | strip_html | truncate: 80 }}</p>
+    </div>
+  </a>
+  
+  <a href="{{site.baseurl}}{{site.posts[1].url}}">
     <div class="four columns news-piece news-piece-1" style="background-image: url({{site.baseurl}}/img/{{site.posts[1].img}});">
-     <p class="news-title">{{site.posts[1].title}}</p>
-     <p class="news-exp">{{site.posts[1].excerpt | strip_html | truncate: 80 }}</p>
+      <p class="news-title">{{site.posts[1].title}}</p>
+      <p class="news-exp">{{site.posts[1].excerpt | strip_html | truncate: 80 }}</p>
     </div>
-</a>
-
-</div>
-<div class="row row-border">
-   
-   <a href="{{site.baseurl}}{{site.posts[2].url}}">
-    <div class="four columns news-piece news-piece-2 border-2" style="background-image: url({{site.baseurl}}/img/{{site.posts[2].img}});">
-    <p class="news-title">{{site.posts[2].title}}</p>
-    <p class="news-exp">{{site.posts[2].excerpt | strip_html | truncate: 80 }}</p>
-    </div>
-     </a>
-     
-    <a href="{{site.baseurl}}{{site.posts[3].url}}">
-    <div class="four columns news-piece news-piece-2 border" style="background-image: url({{site.baseurl}}/img/{{site.posts[3].img}});"> 
-    <p class="news-title">{{site.posts[3].title}}</p>
-    <p class="news-exp">{{site.posts[3].excerpt | strip_html | truncate: 80 }}</p>
-    </div>
-    </a>
-    
-    <a href="{{site.baseurl}}{{site.posts[4].url}}">
-    <div class="four columns news-piece news-piece-2" style="background-image: url({{site.baseurl}}/img/{{site.posts[4].img}});"> 
-    <p class="news-title">{{site.posts[4].title}}</p>
-    <p class="news-exp">{{site.posts[4].excerpt | strip_html | truncate: 80 }}</p>
-    </div>
-    </a>
-    
+  </a>
 </div>
 
 
 <div class="row row-border">
-   
-   <a href="{{site.baseurl}}{{site.posts[5].url}}">
-    <div class="four columns news-piece news-piece-2 border-2" style="background-image: url({{site.baseurl}}/img/{{site.posts[5].img}});">
-    <p class="news-title">{{site.posts[5].title}}</p>
-    <p class="news-exp">{{site.posts[5].excerpt | strip_html | truncate: 80 }}</p>
-    </div>
-     </a>
-     
-    <a href="{{site.baseurl}}{{site.posts[6].url}}">
-    <div class="four columns news-piece news-piece-2 border" style="background-image: url({{site.baseurl}}/img/{{site.posts[6].img}});"> 
-    <p class="news-title">{{site.posts[6].title}}</p>
-    <p class="news-exp">{{site.posts[6].excerpt | strip_html | truncate: 80 }}</p>
-    </div>
-    </a>
-    
-    <a href="{{site.baseurl}}{{site.posts[7].url}}">
-    <div class="four columns news-piece news-piece-2" style="background-image: url({{site.baseurl}}/img/{{site.posts[7].img}});"> 
-    <p class="news-title">{{site.posts[7].title}}</p>
-    <p class="news-exp">{{site.posts[7].excerpt | strip_html | truncate: 80 }}</p>
-    </div>
-    </a>
-    
+  {% layout_row 2 | 3 %}
 </div>
+
+<div class="row row-border">
+  {% layout_row 5 | 3 %}
+</div>
+
 <div class="row quote">
-   <div class="container">
+  <div class="container">
     <div class="twelve columns">
-        <p class="quote-day">{{page.quote-of-the-day}}</p>
-        <p class="quote-by">- {{page.quote-by}}</p>
+      <p class="quote-day">{{page.quote-of-the-day}}</p>
+      <p class="quote-by">- {{page.quote-by}}</p>
     </div>
-</div>
-</div>
-
-<div class="row row-border">
-
-     <a href="{{site.baseurl}}{{site.posts[8].url}}">
-        <div class="six columns news-piece news-piece-2 border" style="background-image:url({{site.baseurl}}/img/{{site.posts[8].img}})">
-             <p class="news-title">{{site.posts[8].title}}</p>
-            <p class="news-exp">{{site.posts[8].excerpt | strip_html | truncate: 80 }}</p>
-        </div>
-        
-    </a>
-
-     <a href="{{site.baseurl}}{{site.posts[9].url}}">
-        <div class="six columns news-piece news-piece-2" style="background-image:url({{site.baseurl}}/img/{{site.posts[9].img}})">
-        <p class="news-title">{{site.posts[9].title}}</p>
-        <p class="news-exp">{{site.posts[9].excerpt | strip_html | truncate: 80 }}</p>
-        </div>
-    
-    </a>
-
+  </div>
 </div>
 
 <div class="row row-border">
-    <a href="{{site.baseurl}}{{site.posts[10].url}}">
-        <div class="six columns news-piece news-piece-2 border" style="background-image:url({{site.baseurl}}/img/{{site.posts[10].img}})">
-            <p class="news-title">{{site.posts[9].title}}</p>
-        <p class="news-exp">{{site.posts[9].excerpt | strip_html | truncate: 80 }}</p>
-        </div>
-         
-    </a>
+  {% layout_row 8 | 2 %}
+</div>
 
-    <a href="{{site.baseurl}}{{site.posts[11].url}}">
-        <div class="six columns news-piece news-piece-2" style="background-image:url({{site.baseurl}}/img/{{site.posts[11].img}})">
-            <p class="news-title">{{site.posts[9].title}}</p>
-        <p class="news-exp">{{site.posts[9].excerpt | strip_html | truncate: 80 }}</p>
-        </div>
-         
-    </a>
+<div class="row row-border">
+  {% layout_row 10 | 2 %}
+</div>
+
+
+
+</a>
 
 </div>
 


### PR DESCRIPTION
Built a Liquid tag to build the home page. Makes it much easier to modify the layout of the home page. Rows of pictures can easily be added to other pages. Layout of the home page looks a lot nicer when there are insufficient posts to fill the home page provided there are more than 2 posts.